### PR TITLE
chore: use CGO explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ OUTPUT_DIR=./output
 OUTPUT_HEADER_DIR=./output/include
 OUTPUT_LIB_DIR=./output/lib
 
+export CGO_ENABLED=1
+
 build: build-crypto build-crypto-go
 
 release: release-crypto build-crypto-go


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

Just as the title says, use `cgo` explicitly by `CGO_ENABLED=1`

When I execute `make`, it fails on my machine. Then I realize that I do not enable `cgo` on my machine. We could not also assume that other developers enable `cgo`, so it's better to clarify it explicitly. 
